### PR TITLE
Add `tomorrow-night-bright-r-classic` to extension pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- 
   All notable changes to the "positron-plus-1-e" extension pack will be documented in this file.
 
+- Add [tomorrow-night-bright-r-classic](https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic) to the extension pack
+
   Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Change Log
 
-<!-- 
+<!--
   All notable changes to the "positron-plus-1-e" extension pack will be documented in this file.
 
-- Add [tomorrow-night-bright-r-classic](https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic) to the extension pack
-
-  Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. 
+  Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 -->
+
+## [0.0.6]
+
+- Added [tomorrow-night-bright-r-classic](https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic) to the extension pack
 
 ## [0.0.5]
 

--- a/README.md
+++ b/README.md
@@ -50,5 +50,6 @@ Recommendations, suggestions, comments and PRs are welcome!
 
 -  [bierner.color-info](https://open-vsx.org/extension/bierner/color-info) - Displays color information for a given color code.
 -  [github.github-vscode-theme](https://open-vsx.org/extension/github/github-vscode-theme) - The official GitHub Visual Studio Code theme.
+-  [gvelasq.tomorrow-night-bright-r-classic](https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic) - A theme inspired by Posit's implementation of the Tomorrow Night Bright theme in the RStudio IDE.
 -  [mechatroner.rainbow-csv](https://open-vsx.org/extension/mechatroner/rainbow-csv) - Highlights CSV files in different colors.
 -  [johnpapa.vscode-peacock](https://open-vsx.org/extension/johnpapa/vscode-peacock) - Subtly customize IDE appearance to differentiate between different project windows.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "github.vscode-github-actions",
     "github.vscode-pull-request-github",
     "gruntfuggly.todo-tree",
+    "gvelasq.tomorrow-night-bright-r-classic",
     "johnpapa.vscode-peacock",
     "mechatroner.rainbow-csv",
     "mhutchie.git-graph",


### PR DESCRIPTION
This PR by @ivelasq and I adds a new color theme, `tomorrow-night-bright-r-classic`.

The editor colors are inspired by Posit’s implementation of Tomorrow Night Bright in the RStudio IDE, and the workbench colors are inspired by Microsoft’s implementation of GitHub Dark Default (with Tomorrow Night Bright accent colors). It will be featured in @ivelasq's blog soon!

Thank you for considering.